### PR TITLE
Nits housekeeping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+TEXT_PAGINATION := true
 LIBDIR := lib
 include $(LIBDIR)/main.mk
 

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -31,7 +31,6 @@ author:
 normative:
     RFC8949: CBOR
     RFC8610: CDDL
-    RFC7942: RFC7942
     CDE:
         title: "Bormann, C., \"CBOR Common Deterministic Encoding (CDE)\""
         target: https://datatracker.ietf.org/doc/draft-ietf-cbor-cde/
@@ -190,14 +189,8 @@ leaf = #6.24(bytes .dcbor any)
 ~~~
 
 # Reference Implementations
-
-This section is to be removed before publishing as an RFC.
-
-(Boilerplate as per Section 2.1 of {{RFC7942}}:)
-
-This section records the status of known implementations of the protocol defined by this specification at the time of posting of this Internet-Draft, and is based on a proposal described in {{RFC7942}}. The description of implementations in this section is intended to assist the IETF in its decision processes in progressing drafts to RFCs. Please note that the listing of any individual implementation here does not imply endorsement by the IETF. Furthermore, no effort has been spent to verify the information presented here that was supplied by IETF contributors. This is not intended as, and must not be construed to be, a catalog of available implementations or their features. Readers are advised to note that other implementations may exist.
-
-According to {{RFC7942}}, "this will allow reviewers and working groups to assign due consideration to documents that have the benefit of running code, which may serve as evidence of valuable experimentation and feedback that have made the implemented protocols more mature. It is up to the individual working groups to use this information as they see fit".
+{:removeinrfc}
+{::boilerplate rfc7942info}
 
 ## Gordian dCBOR Application Profile
 

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -256,6 +256,7 @@ This document requests IANA to register the contents of Table 1 into the registr
 |:-----------|:----------|
 | .dcbor     | \[RFCXXXX\] |
 | .dcborseq  | \[RFCXXXX\] |
+{: title="CDDL Control Operators for dCBOR"}
 
 --- back
 

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -146,7 +146,7 @@ This also means that the three representations of a zero number in CBOR (`0`, `0
 
 Note that this reduction means some valid CDE/CBOR maps are not valid dCBOR maps, as numeric reduction can result in duplicate keys, for example, this is an invalid dCBOR map:
 
-~~~
+~~~ cbor-diag
 {
    10: "ten",
    10.0: "floating ten"
@@ -182,13 +182,13 @@ The control operators `.dcbor` and `.dcborseq` are exactly like `.cde` and `.cde
 
 For example, the normative comment in Section 3 of {{GordianEnvelope}}:
 
-~~~
+~~~ cddl
 leaf = #6.24(bytes)  ; MUST be dCBOR
 ~~~
 
 ...can now be formalized as:
 
-~~~
+~~~ cddl
 leaf = #6.24(bytes .dcbor any)
 ~~~
 

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -1,4 +1,6 @@
 ---
+v: 3
+
 title: "dCBOR: A Deterministic CBOR Application Profile"
 abbrev: "dCBOR"
 docname: draft-mcnally-deterministic-cbor-latest
@@ -10,23 +12,18 @@ area: Applications and Real-Time
 workgroup: Network Working Group
 keyword: Internet-Draft
 
-stand_alone: yes
-smart_quotes: no
 pi: [toc, sortrefs, symrefs]
 
 author:
  -
-    ins: W. McNally
     name: Wolf McNally
     organization: Blockchain Commons
     email: wolf@wolfmcnally.com
  -
-    ins: C. Allen
     name: Christopher Allen
     organization: Blockchain Commons
     email: christophera@lifewithalacrity.com
  -
-    ins: C. Bormann
     name: Carsten Bormann
     organization: Universität Bremen TZI
     email: cabo@tzi.org

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -31,12 +31,8 @@ author:
 normative:
     RFC8949: CBOR
     RFC8610: CDDL
-    CDE:
-        title: "Bormann, C., \"CBOR Common Deterministic Encoding (CDE)\""
-        target: https://datatracker.ietf.org/doc/draft-ietf-cbor-cde/
-    IANACDDL:
-        title: "Concise Data Definition Language (CDDL)"
-        target: https://www.iana.org/assignments/cddl
+    CDE: I-D.draft-ietf-cbor-cde
+    IANACDDL: IANA.cddl
 
 informative:
     BCSwiftDCBOR:
@@ -48,9 +44,7 @@ informative:
     BCTypescriptDCBOR:
         title: "McNally, W., \"Deterministic CBOR (dCBOR) for Typescript.\""
         target: https://github.com/BlockchainCommons/bc-dcbor-ts
-    GordianEnvelope:
-        title: "McNally, W., \"Gordian Envelope\""
-        target: https://www.ietf.org/archive/id/draft-mcnally-envelope-05.html
+    GordianEnvelope: I-D.mcnally-envelope
     cbor-deterministic:
         title: "Bormann, C., \"cbor-deterministic gem\""
         target: https://github.com/cabo/cbor-deterministic

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -110,7 +110,7 @@ CBOR {{-CBOR}} defines maps with duplicate keys as invalid, but leaves how to ha
 
 dCBOR encoders:
 
-1. MUST NOT emit CBOR maps that contains duplicate keys.
+1. MUST NOT emit CBOR maps that contain duplicate keys.
 
 dCBOR decoders:
 

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -198,9 +198,7 @@ leaf = #6.24(bytes .dcbor any)
 {:removeinrfc}
 {::boilerplate rfc7942info}
 
-## Gordian dCBOR Application Profile
-
-### Swift
+## Swift
 
 - Description: Single-purpose dCBOR reference implementation for Swift.
 - Organization: Blockchain Commons
@@ -211,7 +209,7 @@ leaf = #6.24(bytes .dcbor any)
 - Testing: Unit tests
 - Licensing: BSD-2-Clause-Patent
 
-### Rust
+## Rust
 
 - Description: Single-purpose dCBOR reference implementation for Rust.
 - Organization: Blockchain Commons
@@ -222,7 +220,7 @@ leaf = #6.24(bytes .dcbor any)
 - Testing: Unit tests
 - Licensing: BSD-2-Clause-Patent
 
-### TypeScript
+## TypeScript
 
 - Description: Single-purpose dCBOR reference implementation for TypeScript.
 - Organization: Blockchain Commons
@@ -233,7 +231,7 @@ leaf = #6.24(bytes .dcbor any)
 - Testing: Unit tests
 - Licensing: BSD-2-Clause-Patent
 
-### Ruby
+## Ruby
 
 - Implementation Location: [cbor-dcbor]
 - Primary Maintainer: Carsten Bormann

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -194,7 +194,7 @@ leaf = #6.24(bytes)  ; MUST be dCBOR
 leaf = #6.24(bytes .dcbor any)
 ~~~
 
-# Reference Implementations
+# Implementation Status
 {:removeinrfc}
 {::boilerplate rfc7942info}
 

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -14,6 +14,11 @@ keyword: Internet-Draft
 
 pi: [toc, sortrefs, symrefs]
 
+venue:
+#  group: "CBOR Maintenance and Extensions"
+#  mail: "cbor@ietf.org"
+  github: BlockchainCommons/WIPs-IETF-draft-deterministic-cbor
+
 author:
  -
     name: Wolf McNally

--- a/draft-mcnally-deterministic-cbor.md
+++ b/draft-mcnally-deterministic-cbor.md
@@ -36,23 +36,35 @@ normative:
 
 informative:
     BCSwiftDCBOR:
-        title: "McNally, W., \"Deterministic CBOR (dCBOR) for Swift.\""
+        author:
+            name: Wolf McNally
+        title: "Deterministic CBOR (dCBOR) for Swift."
         target: https://github.com/BlockchainCommons/BCSwiftDCBOR
     BCRustDCBOR:
-        title: "McNally, W., \"Deterministic CBOR (dCBOR) for Rust.\""
+        author:
+            name: Wolf McNally
+        title: "Deterministic CBOR (dCBOR) for Rust."
         target: https://github.com/BlockchainCommons/bc-dcbor-rust
     BCTypescriptDCBOR:
-        title: "McNally, W., \"Deterministic CBOR (dCBOR) for Typescript.\""
+        author:
+            name: Wolf McNally
+        title: "Deterministic CBOR (dCBOR) for Typescript."
         target: https://github.com/BlockchainCommons/bc-dcbor-ts
     GordianEnvelope: I-D.mcnally-envelope
     cbor-deterministic:
-        title: "Bormann, C., \"cbor-deterministic gem\""
+        author:
+            name: Carsten Bormann
+        title: "cbor-deterministic gem"
         target: https://github.com/cabo/cbor-deterministic
     cbor-diag:
-        title: "Bormann, C., \"CBOR diagnostic utilities\""
+        author:
+            name: Carsten Bormann
+        title: "CBOR diagnostic utilities"
         target: https://github.com/cabo/cbor-diag
     cbor-dcbor:
-        title: "Bormann, C., \"PoC of the McNally/Allen dCBOR application-level CBOR representation rules\""
+        author:
+            name: Carsten Bormann
+        title: "PoC of the McNally/Allen dCBOR application-level CBOR representation rules"
         target: https://github.com/cabo/cbor-dcbor
 
 --- abstract


### PR DESCRIPTION
Starting out with some general document cleanup.

Should we include the CBOR mailing list in the venue information?

I prefer "implementer" (~8632 occurrences in RFCs) over "implementor" (4578), but that is not a strong preference.
